### PR TITLE
fix tab margin bug

### DIFF
--- a/src/styles/AlyaRussian.module.scss
+++ b/src/styles/AlyaRussian.module.scss
@@ -1,6 +1,7 @@
 .alyaTabs {
   width: 70%;
-  margin: auto;
+  margin-left: auto;
+  margin-right: auto;
 
   &.portrait {
     width: 100%;

--- a/src/styles/MygoQuiz.module.scss
+++ b/src/styles/MygoQuiz.module.scss
@@ -4,7 +4,8 @@
 
 .mygoTabs {
   width: 70%;
-  margin: auto;
+  margin-left: auto;
+  margin-right: auto;
 
   &.portrait {
     width: 100%;


### PR DESCRIPTION
タブを中央配置にするためのCSSによってタブ下のマージンが打ち消されていた