### PR TITLE
fix locale bug priority setting

### DIFF
--- a/src/hooks/useLocaleSlug.ts
+++ b/src/hooks/useLocaleSlug.ts
@@ -30,6 +30,13 @@ export const useLocaleSlug = () => {
   return i18nextLocale
 }
 
+export const useUrlLocaleSlug = () => {
+  const router = useRouter()
+  const { locale_slug } = router.query
+
+  return locale_slug as string
+}
+
 export const useDefaultLocale = () => {
   const [defaultLocale, setDefaultLocale] = useState(LOCALE.JAPANESE.DEFAULT)
 
@@ -45,13 +52,15 @@ export const useRouterLocale = () => {
   const localeSlug = useLocaleSlug()
 
   const routerNewUrl = (locale: string) => {
-    const { ...queries } = router.query
-    const updatedQuery = {
-      ...queries,
-      locale_slug: locale
+    const { locale_slug, ...queries } = router.query
+    if (locale_slug) {
+      const updatedQuery = {
+        ...queries,
+        locale_slug: locale
+      }
+      router.replace({ query: updatedQuery }, undefined, { shallow: true })
+      localStorage.setItem(I18NEXT_LOCALE, locale)
     }
-    router.push({ query: updatedQuery })
-    localStorage.setItem(I18NEXT_LOCALE, locale)
   }
 
   return { localeSlug, routerNewUrl }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,18 +7,28 @@ import '@/locales/config'
 
 import { CustomProvider } from '@/components/customProvider'
 import { LayoutWithMenu } from '@/components/layout'
-import { useLocaleSlug, I18NEXT_LOCALE } from '@/hooks/useLocaleSlug'
+import {
+  useLocaleSlug,
+  I18NEXT_LOCALE,
+  useUrlLocaleSlug,
+  useRouterLocale
+} from '@/hooks/useLocaleSlug'
 
 import '@/styles/globals.scss'
-
 const App = ({ Component, pageProps }: AppProps) => {
-  const locale = useLocaleSlug()
   const { i18n } = useTranslation()
+  const locale = useLocaleSlug()
+  const urlLanguage = useUrlLocaleSlug()
+  const { routerNewUrl } = useRouterLocale()
 
   useEffect(() => {
     i18n.changeLanguage(locale)
     localStorage.setItem(I18NEXT_LOCALE, locale)
-  }, [i18n, locale])
+    if (urlLanguage !== locale) {
+      routerNewUrl(locale)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [i18n, locale, urlLanguage])
 
   return (
     <RecoilRoot>


### PR DESCRIPTION
手打ちしたロケールに反応してページの言語が切り替わっていなかった

→設定を優先としたため設定と違うロケールが手動入力されたとき設定に合わせてリダイレクトされる